### PR TITLE
Create directory in both cases

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -17,8 +17,8 @@ def get_dir(cfg, param_name, new_dir_name):
         dir_name = cfg[param_name]
     else:
         dir_name = os.path.join(os.path.dirname(__file__), new_dir_name)
-        if not os.path.exists(dir_name):
-            os.makedirs(dir_name)
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
     return dir_name
 
 


### PR DESCRIPTION
Currently, `get_dir` doesn't create the directory if the value was specified in the config file, which will raise `FileNotFoundError` at the end of the dataset creation script. 
This fixes that.

Also, you can use `os.makedirs(dir_name, exist_ok=True)`.