### PR TITLE
tar should use gzip instead of bzip for dns5 headset training dataset

### DIFF
--- a/download-dns-challenge-5-headset-training.sh
+++ b/download-dns-challenge-5-headset-training.sh
@@ -129,5 +129,5 @@ do
     # wget "$URL" -O "$OUTPUT_PATH/$BLOB"
 
     # Same, + unpack files on the fly
-    # curl "$URL" | tar -C "$OUTPUT_PATH" -f - -x -j
+    # curl "$URL" | tar -C "$OUTPUT_PATH" -f - -x -z
 done


### PR DESCRIPTION
tiny fix to downloader