### PR TITLE
Explicitly specify the paths for onnx models

### DIFF
--- a/DNSMOS/dnsmos_local.py
+++ b/DNSMOS/dnsmos_local.py
@@ -102,12 +102,13 @@ class ComputeScore:
 def main(args):
     models = glob.glob(os.path.join(args.testset_dir, "*"))
     audio_clips_list = []
-    p808_model_path = os.path.join('DNSMOS', 'model_v8.onnx')
+    dnsmos_abs_path = os.path.dirname(os.path.abspath(__file__))
+    p808_model_path = os.path.join(dnsmos_abs_path, 'DNSMOS', 'model_v8.onnx')
 
     if args.personalized_MOS:
-        primary_model_path = os.path.join('pDNSMOS', 'sig_bak_ovr.onnx')
+        primary_model_path = os.path.join(dnsmos_abs_path, 'pDNSMOS', 'sig_bak_ovr.onnx')
     else:
-        primary_model_path = os.path.join('DNSMOS', 'sig_bak_ovr.onnx')
+        primary_model_path = os.path.join(dnsmos_abs_path, 'DNSMOS', 'sig_bak_ovr.onnx')
 
     compute_score = ComputeScore(primary_model_path, p808_model_path)
 


### PR DESCRIPTION
# Problem

The current implementation of dnsmos_local.py assumes the script is called from the same directory as dnsmos_local.py. Therefore, you need to move to the "DNSMOS" directory when you execute the script.

# My implementation

I added one line of code to get the absolute path of the "DNSMOS" directory where dnsmos_local.py resides. By specifying the onnx models relative to this path, the paths of the onnx models can be always resolved regardless of where dnsmos_local.py is called from. This makes using the script a lot more easier.

```python
dnsmos_abs_path = os.path.dirname(os.path.abspath(__file__))
```